### PR TITLE
Force MegEngine version 1.8.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-MegEngine>=1.8.2
+MegEngine==1.8.2
 opencv-python>=3.4.0
 numpy>=1.18.1
 Pillow>=8.4.0


### PR DESCRIPTION
This solves an issue with newer versions of MegEngine (https://github.com/megvii-research/CREStereo/issues/13)