### PR TITLE
Update requirements.txt to MegEngine v1.9.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-MegEngine==1.8.2
+MegEngine>=1.9.1
 opencv-python>=3.4.0
 numpy>=1.18.1
 Pillow>=8.4.0


### PR DESCRIPTION
`function.Pad` may lead to some weird NaN in MegEngine v1.8.2, MegEngine v1.9.0 resolve this but brings more problems, which is pointed out in https://github.com/megvii-research/CREStereo/pull/14 .

The most recent release v1.9.1 resolves all of these problems, updates MegEngine version constraint to v1.9.1 or later